### PR TITLE
Update check-declined-granted-permission.php

### DIFF
--- a/check-declined-granted-permission.php
+++ b/check-declined-granted-permission.php
@@ -65,7 +65,7 @@ if (isset($accessToken)) {
 	foreach ($permissions as $key) {
 		if ($key['status'] == 'declined') {
 			$declined[] = $key['permission'];
-			$loginUrl = $helper->getLoginUrl('http://sohaibilyas.com/APP_DIR/', $declined);
+			$loginUrl = $helper->getReRequestUrl('http://sohaibilyas.com/APP_DIR/', $declined);
 			echo '<a href="' . $loginUrl . '">Log in with Facebook!</a>';
 		}
 	}


### PR DESCRIPTION
Tested using API 2.11.
1. Request public_profile, email, user_birthday and publish_actions
2. User declined email and publish_actions permissions 
3. Call getLoginUrl passing the callback URL and the declined array
4. Facebook just show the publish_actions window. 
5. After user grants publish_actions, Facebook cannot show email permission grant window. 

If you call **getReRequestUrl** for both permissions, Facebook will open the public_actions, when check for declined permission still have email permission declined,  thenFacebook will show email permission grant window.